### PR TITLE
Fix Ruff lint failures

### DIFF
--- a/jupyter_templates/__init__.py
+++ b/jupyter_templates/__init__.py
@@ -5,7 +5,7 @@
 # This file is part of the jupyter_templates library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
-from .extension import _load_jupyter_server_extension, load_jupyter_server_extension  # noqa: F401
+from .extension import _load_jupyter_server_extension, load_jupyter_server_extension
 from .nbextension import _jupyter_nbextension_paths
 
 __version__ = "0.1.1"

--- a/jupyter_templates/extension.py
+++ b/jupyter_templates/extension.py
@@ -5,12 +5,12 @@
 # This file is part of the jupyter_templates library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
+import builtins
 import json
 import os
 import os.path
 from fnmatch import fnmatch
 from functools import partial
-from io import open
 
 import jupyter_core.paths
 import tornado.web
@@ -58,7 +58,7 @@ class TemplatesLoader:
             for f, dirname, filename in files:
                 # skips over faild attempts to read content
                 try:
-                    with open(os.path.join(abspath, f), "r", encoding="utf8") as fp:
+                    with builtins.open(os.path.join(abspath, f), "r", encoding="utf8") as fp:
                         content = fp.read()
                 except (FileNotFoundError, PermissionError):
                     # Can't read file, skip
@@ -143,17 +143,17 @@ def _load_jupyter_server_extension(nb_server_app, nb6_entrypoint=False):
 
     base_url = web_app.settings["base_url"]
     host_pattern = ".*$"
-    nb_server_app.log.info("Installing jupyter_templates handler on path %s" % url_path_join(base_url, "templates"))
+    nb_server_app.log.info("Installing jupyter_templates handler on path %s", url_path_join(base_url, "templates"))
 
     if nb_server_app.config.get("JupyterLabTemplates", {}).get("include_core_paths", True):
         template_dirs.extend([os.path.join(x, "notebook_templates") for x in jupyter_core.paths.jupyter_path()])
-    nb_server_app.log.info("Search paths:\n\t%s" % "\n\t".join(template_dirs))
+    nb_server_app.log.info("Search paths:\n\t%s", "\n\t".join(template_dirs))
 
     template_label = nb_server_app.config.get("JupyterLabTemplates", {}).get("template_label", "Template")
-    nb_server_app.log.info("Template label: %s" % template_label)
+    nb_server_app.log.info("Template label: %s", template_label)
 
     loader = TemplatesLoader(template_dirs, allowed_extensions=allowed_extensions, template_label=template_label)
-    nb_server_app.log.info("Available templates:\n\t%s" % "\n\t".join(t for t in loader.get_templates()[1].keys()))
+    nb_server_app.log.info("Available templates:\n\t%s", "\n\t".join(loader.get_templates()[1]))
 
     web_app.add_handlers(
         host_pattern,

--- a/jupyter_templates/tests/test_all.py
+++ b/jupyter_templates/tests/test_all.py
@@ -6,5 +6,5 @@
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
 # for Coverage
-from jupyter_templates import *  # noqa: F401, F403
-from jupyter_templates.extension import *  # noqa: F401, F403
+from jupyter_templates import *
+from jupyter_templates.extension import *


### PR DESCRIPTION
## Description

Update Python code for current Ruff checks without changing lint configuration. Remove obsolete suppression comments, use explicit built-in file opening, replace percent-formatted log expressions with lazy logging arguments, and remove an unnecessary `dict.keys()` call.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [ ] New tests added for new functionality (not applicable)
- [ ] Documentation updated (not applicable)
- [ ] Changelog / version bump (not applicable)